### PR TITLE
[fix] Pudo Object id intval conversion dropped

### DIFF
--- a/src/Fancourier/Objects/Pudo.php
+++ b/src/Fancourier/Objects/Pudo.php
@@ -10,95 +10,93 @@ class Pudo
 	protected $description;
 	protected $latitude;
 	protected $longitude;
-	
+
 	protected $address;
-	
+
 	protected $schedule;
 	protected $drawer;
-	
+
 	protected $phones;	// array
 	protected $email;
-	
+
 	public function __construct($data)
-		{
-		$this->id				= intval($data['id'] ?? 0);
+	{
+		$this->id				= $data['id'] ?? 0;
 		$this->name				= $data['name'] ?? '';
 		$this->routingLocation	= $data['routingLocation'] ?? '';
 		$this->description		= $data['description'] ?? '';
-		
+
 		$this->address			= $data['address'] ?? [];
-		
+
 		$this->latitude			= $data['latitude'] ?? '';
 		$this->longitude		= $data['longitude'] ?? '';
-		
+
 		$this->schedule			= $data['schedule'] ?? [];
 		$this->drawer			= $data['drawer'] ?? [];
-		
+
 		$this->phones			= $data['phones'] ?? [];
-		
+
 		$this->email			= $data['email'] ?? '';
-		}
-	
+	}
+
 	public function getId(): string
-		{
+	{
 		return $this->id;
-		}
-	
+	}
+
 	public function getName(): string
-		{
+	{
 		return $this->name ?? '';
-		}
-		
+	}
+
 	public function getRoutingLocation(): string
-		{
+	{
 		return $this->routingLocation ?? '';
-		}
-	
+	}
+
 	public function getDescription(): string
-		{
+	{
 		return $this->description ?? '';
-		}
-	
+	}
+
 	public function getLatitude(): string
-		{
+	{
 		return $this->latitude ?? '';
-		}
-	
+	}
+
 	public function getLongitude(): string
-		{
+	{
 		return $this->longitude ?? '';
-		}
-	
+	}
+
 	public function getAddress(): array
-		{
+	{
 		return $this->address ?? '';
-		}
-	
+	}
+
 	public function getSchedule() //: array|string
-		{
+	{
 		return $this->schedule ?? '';
-		}
-	
+	}
+
 	public function getDrawer() //: array|string
-		{
+	{
 		return $this->drawer ?? '';
-		}
-	
+	}
+
 	public function getPhones() //: array|string
-		{
+	{
 		return $this->phones ?? '';
-		}
-	
+	}
+
 	public function getEmail(): string
-		{
+	{
 		return $this->email ?? '';
-		}
-	
-	
-	
+	}
+
 	/* return array with data similar to fan courier api response */
 	public function getArray(): array
-		{
+	{
 		$arr = [
 			"id"				=> $this->id,
 			"name"				=> $this->name,
@@ -111,9 +109,8 @@ class Pudo
 			"drawer"			=> $this->drawer,
 			"phones"			=> $this->phones,
 			"email"				=> $this->email,
-			];
-		
+		];
+
 		return $arr;
-		}
-	
+	}
 }


### PR DESCRIPTION
Dropped the casting of the `Objects\Pudo` id to int.

FAN Api change has the following returned ids:
* FANBox starts with **F**: _F1000013_
* PayPoint starts with **P**: _P139763_
* Office starts with **S**: _S101_

The intval() made them all return 0, therefore the ->getId() was always returning 0 because of the wrongful mapping.