### PR TITLE
[fix] Creation of dynamic property deprecation

### DIFF
--- a/src/Fancourier/Objects/BankTransfer.php
+++ b/src/Fancourier/Objects/BankTransfer.php
@@ -13,101 +13,103 @@ class BankTransfer
 	protected $transferDate;
 	protected $transactionType;
 	protected $transactionDate;
-	
+
 	protected $recipientName;
 	protected $recipientContactPerson;
 	protected $recipientCity;
-	
+
+	protected $senderName;
+	protected $senderContactPerson;
+
 	public function __construct($data)
-		{
+	{
 		$this->awbNumber				= $data['info']['awbNumber'] ?? '';
- 		$this->awbDate					= $data['info']['awbDate'] ?? '';
- 		$this->returnAwbNumber			= $data['info']['returnAwbNumber'] ?? '';
- 		$this->reimbursementAwbNumber	= $data['info']['reimbursementAwbNumber'] ?? '';
- 		$this->amountCollected			= $data['info']['amountCollected'] ?? 0;
- 		$this->content					= $data['info']['content'] ?? '';
- 		$this->transferDate				= $data['info']['transferDate'] ?? '';
- 		$this->transactionType			= $data['info']['transactionType'] ?? '';
- 		$this->transactionDate			= $data['info']['transactionDate'] ?? '';
-		
+		$this->awbDate					= $data['info']['awbDate'] ?? '';
+		$this->returnAwbNumber			= $data['info']['returnAwbNumber'] ?? '';
+		$this->reimbursementAwbNumber	= $data['info']['reimbursementAwbNumber'] ?? '';
+		$this->amountCollected			= $data['info']['amountCollected'] ?? 0;
+		$this->content					= $data['info']['content'] ?? '';
+		$this->transferDate				= $data['info']['transferDate'] ?? '';
+		$this->transactionType			= $data['info']['transactionType'] ?? '';
+		$this->transactionDate			= $data['info']['transactionDate'] ?? '';
+
 		$this->recipientName			= $data['recipient']['name'] ?? '';
 		$this->recipientContactPerson	= $data['recipient']['contactPerson'] ?? '';
 		$this->recipientCity			= $data['recipient']['address']['locality'] ?? '';
-		
+
 		$this->senderName				= $data['sender']['name'] ?? '';
 		$this->senderContactPerson		= $data['sender']['contactPerson'] ?? '';
-		}
-	
-	public function getAwbNumber(): string
-		{
-		return $this->awbNumber;
-		}
-	
-	public function getAwbDate(): string
-		{
-		return $this->awbDate;
-		}
-	
-	public function getReturnAwbNumber(): string
-		{
-		return $this->returnAwbNumber;
-		}
-	
-	public function getReimbursementAwbNumber(): string
-		{
-		return $this->reimbursementAwbNumber;
-		}
-	
-	public function getAmountCollected(): float
-		{
-		return $this->amountCollected;
-		}
-	
-	public function getContent(): string
-		{
-		return $this->content;
-		}
-	
-	public function getTransferDate(): string
-		{
-		return $this->transferDate;
-		}
-	
-	public function getTransactionType(): string
-		{
-		return $this->transactionType;
-		}
-	
-	public function getTransactionDate(): string
-		{
-		return $this->transactionDate;
-		}
-	
-	public function getRecipientName(): string
-		{
-		return $this->recipientName;
-		}
-	
-	public function getRecipientContactPerson(): string
-		{
-		return $this->recipientContactPerson;
-		}
-	
-	public function getRecipientCity(): string
-		{
-		return $this->recipientCity;
-		}
-	
-	public function getSenderName(): string
-		{
-		return $this->senderName;
-		}
-	
-	public function getSenderContactPerson(): string
-		{
-		return $this->senderContactPerson;
-		}
+	}
 
+	public function getAwbNumber(): string
+	{
+		return $this->awbNumber;
+	}
+
+	public function getAwbDate(): string
+	{
+		return $this->awbDate;
+	}
+
+	public function getReturnAwbNumber(): string
+	{
+		return $this->returnAwbNumber;
+	}
+
+	public function getReimbursementAwbNumber(): string
+	{
+		return $this->reimbursementAwbNumber;
+	}
+
+	public function getAmountCollected(): float
+	{
+		return $this->amountCollected;
+	}
+
+	public function getContent(): string
+	{
+		return $this->content;
+	}
+
+	public function getTransferDate(): string
+	{
+		return $this->transferDate;
+	}
+
+	public function getTransactionType(): string
+	{
+		return $this->transactionType;
+	}
+
+	public function getTransactionDate(): string
+	{
+		return $this->transactionDate;
+	}
+
+	public function getRecipientName(): string
+	{
+		return $this->recipientName;
+	}
+
+	public function getRecipientContactPerson(): string
+	{
+		return $this->recipientContactPerson;
+	}
+
+	public function getRecipientCity(): string
+	{
+		return $this->recipientCity;
+	}
+
+	public function getSenderName(): string
+	{
+		return $this->senderName;
+	}
+
+	public function getSenderContactPerson(): string
+	{
+		return $this->senderContactPerson;
+	}
 }
 
 
@@ -121,8 +123,8 @@ class BankTransfer
                     [amountCollected] => 670.33
                     [content] => order #6783
                     [transferDate] => 20.11.2023
-                    [returnAwbNumber] => 
-                    [reimbursementAwbNumber] => 
+                    [returnAwbNumber] =>
+                    [reimbursementAwbNumber] =>
                     [transactionType] => cash
                     [transactionDate] => 17.11.2023
                 )
@@ -141,7 +143,7 @@ class BankTransfer
             [sender] => Array
                 (
                     [name] => NETWORK SRL
-                    [contactPerson] => 
+                    [contactPerson] =>
                 )
 
         )
@@ -155,8 +157,8 @@ class BankTransfer
                     [amountCollected] => 375.03
                     [content] => order #6785
                     [transferDate] => 20.11.2023
-                    [returnAwbNumber] => 
-                    [reimbursementAwbNumber] => 
+                    [returnAwbNumber] =>
+                    [reimbursementAwbNumber] =>
                     [transactionType] => cash
                     [transactionDate] => 17.11.2023
                 )
@@ -175,7 +177,7 @@ class BankTransfer
             [sender] => Array
                 (
                     [name] => NETWORK SRL
-                    [contactPerson] => 
+                    [contactPerson] =>
                 )
 
         )


### PR DESCRIPTION
This fixes the deprecation warnings caused by PHP >= 8.2

```
Deprecated: Creation of dynamic property BankTransfer::$senderName is deprecated in ... on line ...
Deprecated: Creation of dynamic property BankTransfer::$senderContactPersonis deprecated in ... on line ...
```