### PR TITLE
[fix] Getter pointing to wrong class property

### DIFF
--- a/src/Fancourier/Request/GetAwbEvents.php
+++ b/src/Fancourier/Request/GetAwbEvents.php
@@ -8,7 +8,7 @@ class GetAwbEvents extends AbstractRequest implements RequestInterface
 {
     protected $gateway = 'reports/awb-events';
 	protected $method = 'GET';
-	
+
     protected $language = '';
 
     public function __construct()
@@ -24,7 +24,7 @@ class GetAwbEvents extends AbstractRequest implements RequestInterface
 			{
 			$arr['language'] = $this->language;
 			}
-		
+
 		return $arr;
     }
 
@@ -33,7 +33,7 @@ class GetAwbEvents extends AbstractRequest implements RequestInterface
      */
     public function getLanguage()
     {
-        return $this->county;
+        return $this->language;
     }
 
     /**


### PR DESCRIPTION
The `getLanguage()` getter was retrieving the wrong class property.