### PR TITLE
Added new expiresAt field for Auth

### DIFF
--- a/src/Fancourier/Auth.php
+++ b/src/Fancourier/Auth.php
@@ -11,6 +11,7 @@ class Auth {
 	private $password;
 
 	private $btoken = '';
+    private $btoken_expires_at = '';
 	private $btoken_message = '';
 
 	protected $verifyHost = true;
@@ -55,6 +56,11 @@ class Auth {
 		return $this->btoken_message;
 		}
 
+	public function getTokenExpiresAt()
+	{
+		return $this->btoken_expires_at; // Date format: Y-m-d H:i:s (unknown timezone)
+	}
+
 	private function retrieve_token()
 		{
 		$client = new Client();
@@ -66,7 +72,7 @@ class Auth {
 			'password' => $this->password
 			];
 		$response = $client->post($url, $data);
-		// {"status":"success","data":{"token":"1811783|P28BQMrSipEdRfPujLKpqKJjoYLyxT8RsW0MxMQ7"}}
+        // {"status":"success","data":{"token":"48944740|EJU0MgzeWY4y1zy9JpQg3cu3cDiqoVg1ZXsIrqLQ","expiresAt":"2024-06-11 07:23:53"}}
 
 		$response_json = json_decode($response, true);
 
@@ -74,7 +80,8 @@ class Auth {
 			{
 			if ($response_json['status'] == 'success')
 				{
-				$this->btoken	= $response_json['data']['token'];
+				$this->btoken = $response_json['data']['token'];
+				$this->btoken_expires_at = $response_json['data']['expiresAt'];
 				}
 			else
 				{

--- a/src/Fancourier/Fancourier.php
+++ b/src/Fancourier/Fancourier.php
@@ -245,7 +245,7 @@ class Fancourier
     {
         return $this->send($request);
     }
-	
+
     /**
      * @param DeleteCourierOrder $request
      * @return \Fancourier\Response\DeleteCourierOrder
@@ -254,7 +254,7 @@ class Fancourier
     {
         return $this->send($request);
     }
-	
+
     /**
      * @param GetCourierOrders $request
      * @return \Fancourier\Response\GetCourierOrders
@@ -263,7 +263,7 @@ class Fancourier
     {
         return $this->send($request);
     }
-	
+
     /**
      * @param GetCourierOrderEvents $request
      * @return \Fancourier\Response\GetCourierOrderEvents
@@ -319,6 +319,14 @@ class Fancourier
     public function getToken($refresh = false)
     {
         return $this->auth->getToken($refresh);
+    }
+
+    /**
+     * @return string
+     */
+    public function getTokenExpiresAt()
+    {
+        return $this->auth->getTokenExpiresAt();
     }
 
     /**


### PR DESCRIPTION
They added a new field on the Auth request that specifies when the returned token will expire on.
```
{"status":"success","data":{"token":"48944740|EJU0MgzeWY4y1zy9JpQg3cu3cDiqoVg1ZXsIrqLQ","expiresAt":"2024-06-11 07:23:53"}}
```
Therefore I added the following:
* A new Auth class property `btoken_expires_at` that will be set at the same time `retrieve_token()` is called.
* A new Auth class method `getTokenExpiresAt()`.
* A new Fancourier class method `getTokenExpiresAt()`.

Sadly, their expiresAt is a bit vague since it's not your typical json date format that includes timezone information ( eg. `2012-12-25T16:30:00.000000Z`. It's just a `Y-m-d H:i:s` format which I did note down in the code. My guess the timezone is Europe\Bucharest.