### PR TITLE
[Feature] Added global setTimeout, and per request setTimeout functionality

### DIFF
--- a/src/Fancourier/Auth.php
+++ b/src/Fancourier/Auth.php
@@ -17,6 +17,9 @@ class Auth {
 	protected $verifyHost = true;
 	protected $verifyPeer = true;
 
+	protected $timeout = 6;
+	protected $con_timeout = 3;
+
 	protected $gateway = 'login';
 
 	public function __construct($clientId, $username, $password, $token = '')
@@ -65,6 +68,8 @@ class Auth {
 		{
 		$client = new Client();
 		$client->set_verify($this->verifyHost, $this->verifyPeer);
+		$client->set_timeout($this->con_timeout, $this->timeout);
+
 		$url = Fancourier::API_URL.$this->gateway;
 
 		$data = [
@@ -103,6 +108,13 @@ class Auth {
     {
         $this->verifyHost = $host;
         $this->verifyPeer = $peer;
+		return $this;
     }
 
+	public function setTimeout($con_timeout = 3, $timeout = 6)
+	{
+		$this->con_timeout = $con_timeout;
+		$this->timeout = $timeout;
+		return $this;
+	}
 }

--- a/src/Fancourier/Client.php
+++ b/src/Fancourier/Client.php
@@ -13,6 +13,9 @@ class Client {
 	private $verify_host = true;
 	private $verify_peer = true;
 
+	private $timeout = 6;
+	private $con_timeout = 3;
+
 	private $useragent	= 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0';
 
 	private $headers	= [];	// custom headers
@@ -28,14 +31,14 @@ class Client {
 	/*
 	* Init curl and set common options. Called by get/post functions
 	*/
-	private function init(int $con_timeout = 60, int $timeout = 600)
+	private function init()
 		{
 		$this->curl = curl_init();
 		// init default data
 		curl_setopt($this->curl, CURLOPT_USERAGENT, $this->useragent);
 
-		curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $con_timeout);
-		curl_setopt($this->curl, CURLOPT_TIMEOUT, $timeout);
+		curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $this->con_timeout);
+		curl_setopt($this->curl, CURLOPT_TIMEOUT, $this->timeout);
 
 		if (!$this->verify_host)
 			{
@@ -73,10 +76,10 @@ class Client {
 		$this->is_delete = false;
 		}
 
-	public function get(string $url, int $con_timeout = 60, int $timeout = 600)//: string|false
+	public function get(string $url)//: string|false
 		{
 		//echo '<div style="font-family:monospace; padding: 5px; border: 1px solid red; margin: 5px">'.$url.'</div>';
-		$this->init($con_timeout, $timeout);
+		$this->init();
 		
 		curl_setopt($this->curl, CURLOPT_URL, $url);
 		//curl_setopt($this->curl, CURLOPT_HEADER, 0);
@@ -127,9 +130,9 @@ class Client {
 		}
 
 
-	public function post(string $url, array $data, int $con_timeout = 60, int $timeout = 600)
+	public function post(string $url, array $data)
 		{
-		$this->init($con_timeout, $timeout);
+		$this->init();
 
 		curl_setopt($this->curl, CURLOPT_URL, $url);
 		//curl_setopt($this->curl, CURLOPT_HEADER, 0);
@@ -160,9 +163,9 @@ class Client {
 		}
 	
 	// curl doesn't like multilevel arrays in CURLOPT_POSTFIELDS, so we have to manually build the data with http_build_query
-	public function post_ma(string $url, array $data, int $con_timeout = 60, int $timeout = 600)
+	public function post_ma(string $url, array $data)
 		{
-		$this->init($con_timeout, $timeout);
+		$this->init();
 
 		$datastr = http_build_query($data, '', '&');
 		$datastr = str_replace(["%5B", "%5D"], ["[", "]"], $datastr);
@@ -200,10 +203,10 @@ class Client {
 		return false;
 		}
 	
-	public function post_json(string $url, array $data, int $con_timeout = 60, int $timeout = 600)//: string|false
+	public function post_json(string $url, array $data)//: string|false
 		{
 		$this->headers_add('Content-Type', 'application/json'); // add content-type to headers
-		$this->init($con_timeout, $timeout);
+		$this->init();
 
 		curl_setopt($this->curl, CURLOPT_URL, $url);
 
@@ -317,6 +320,14 @@ class Client {
 		{
 		$this->verify_host = $host;
 		$this->verify_peer = $peer;
+		return $this;
+		}
+
+	/* if you need a custom request timeout */
+	public function set_timeout($con_timeout = 3, $timeout = 6)
+		{
+		$this->con_timeout = $con_timeout;
+		$this->timeout = $timeout;
 		return $this;
 		}
 

--- a/src/Fancourier/Fancourier.php
+++ b/src/Fancourier/Fancourier.php
@@ -48,6 +48,9 @@ class Fancourier
     protected $verifyHost = true;
     protected $verifyPeer = true;
 
+    protected $conTimeout = 3;
+    protected $timeout = 6;
+
     public function __construct($clientId, $username, $password, $bearer_token = '')
     {
         $this->auth = new Auth($clientId, $username, $password, $bearer_token);
@@ -65,6 +68,20 @@ class Fancourier
         $this->auth->setVerify($verifyHost, $verifyPeer);
         return $this;
     }
+
+    /**
+     * Use this if you need to set a custom request timeout
+     * @param int $conTimeout
+     * @param int $timeout
+     */
+    public function setTimeout($conTimeout = 3, $timeout = 6)
+    {
+        $this->conTimeout = $conTimeout;
+        $this->timeout = $timeout;
+        $this->auth->setTimeout($conTimeout, $timeout);
+        return $this;
+    }
+
     /**
      * @param CreateAwb $request
      * @return \Fancourier\Response\CreateAwb
@@ -310,6 +327,7 @@ class Fancourier
         return $request
             ->authenticate($this->auth)
             ->setVerify($this->verifyHost, $this->verifyPeer)
+            ->setTimeout($this->conTimeout, $this->timeout)
             ->send();
     }
 

--- a/src/Fancourier/Request/AbstractRequest.php
+++ b/src/Fancourier/Request/AbstractRequest.php
@@ -26,6 +26,11 @@ abstract class AbstractRequest implements RequestInterface
     /** @var Client */
     protected $client;
 
+    protected $clientOverrides = [
+        'verify' => false,
+        'timeout' => false
+    ];
+
     /** @var Generic */
     protected $response;
 
@@ -41,11 +46,25 @@ abstract class AbstractRequest implements RequestInterface
         return $this;
     }
 
-	public function setVerify($verifyHost = true, $verifyPeer = true)
-	{
-		$this->client->set_verify($verifyHost, $verifyPeer);
-		return $this;
-	}
+    public function setVerify($verifyHost = true, $verifyPeer = true)
+    {
+        if ($this->clientOverrides['verify'] !== true) {
+            $this->client->set_verify($verifyHost, $verifyPeer);
+            $this->clientOverrides['verify'] = true;
+        }
+
+        return $this;
+    }
+
+    public function setTimeout($conTimeout = 3, $timeout = 6)
+    {
+        if ($this->clientOverrides['timeout'] !== true) {
+            $this->client->set_timeout($conTimeout, $timeout);
+            $this->clientOverrides['timeout'] = true;
+        }
+
+        return $this;
+    }
 
     /**
      * @return Generic

--- a/src/Fancourier/Request/RequestInterface.php
+++ b/src/Fancourier/Request/RequestInterface.php
@@ -8,6 +8,7 @@ interface RequestInterface
 {
     public function authenticate(Auth $auth);
     public function setVerify($verifyHost, $verifyPeer);
+    public function setTimeout($conTimeout, $timeout);
     public function send();
     public function pack();
 }


### PR DESCRIPTION
Added a new functionality called `setTimeout()` that's made to work the same way as `setVerify()`.

- Removed the `$con_timeout` and `$timeout` parameters from the Client class `init()` function.
- Reduced the connection timeout and timeout to some sensible values (3 seconds for connection/TTFB and 6 seconds for transfer timeout, to prevent PHP process lockdown - previously if the FanCourier servers were not answering, the Client would timeout after 10 minutes or whenever PHP max_execution_time was reached, which is an undesired outcome).
- Added a new `set_timeout($con_timeout = 3, $timeout = 6)` to the Client class.
- Added a new `setTimeout($conTimeout = 3, $timeout = 6)` to the Fancourier class, this way they get set global timeout values.

1.  You can now set default timeout values per `Fancourier` class instance, and this will be used in every subsequent call.
2.  You can set per request timeout values that will overwrite the default values.

The above logic also applies for `setVerify()` which used to be broken because point [2] did not work. Fancourier verify values were always used, even if you set a single request to other values.

### Examples
______

```php
$client = new \Fancourier\Fancourier(
    username: 'clienttest',
    password: 'testing',
    clientId: 7032158,
);

$client->setTimeout(10, 15); // This will set the connection timeout to 10 seconds and the response timeout to 15 seconds as default values for all requests

$trackAwbRequest = new \Fancourier\Request\TrackAwb();
$trackAwbRequest->setTimeout(10, 15); // This will set the connection timeout to 10 seconds and the response timeout to 15 seconds for this request only
$trackAwbRequest->addAwb('EXAMPLE AWB NUMBER');
$client->trackAwb($trackAwbRequest);
```