### PR TITLE
Fix GetCosts.php

### DIFF
--- a/src/Fancourier/Request/GetCosts.php
+++ b/src/Fancourier/Request/GetCosts.php
@@ -47,10 +47,9 @@ class GetCosts extends AbstractRequest implements RequestInterface
 						],
 			];
 
-		if ($this->options != '')
-			{
-			$arr['info']['options'] = $this->options;
-			}
+		if ($this->options != '') {
+		    $arr['info']['options'] = str_split($this->options);
+		}
 
 		if ( ($this->width > 0) && ($this->height > 0) && ($this->length > 0) )
 			{


### PR DESCRIPTION
// Options must be an array, not a string 
if ($this->options != '') {
    $arr['info']['options'] = str_split($this->options); // wrong: expects array, not string
}