### PR TITLE
fix: unidentified array key "message"

### DIFF
--- a/src/Fancourier/Response/CreateAwb.php
+++ b/src/Fancourier/Response/CreateAwb.php
@@ -76,7 +76,7 @@ class CreateAwb extends Generic implements ResponseInterface
 				}
 			else
 				{
-				$this->setErrorMessage($response_json['message']);
+				$this->setErrorMessage($response_json['message'] ?? $response_json['errors'] ?? 'Unknown error');
 				$this->setErrorCode(-1);
 				}
 			}


### PR DESCRIPTION
Modified the assignment of the error message to use `message`, falling back to `errors`, and finally to `'Unknown error'` if neither is present in the response JSON.

There seems to be a special case where FAN decided to return a different array key:
<img width="631" height="52" alt="Screenshot 2025-10-03 at 13 53 48" src="https://github.com/user-attachments/assets/e20ecb7c-dd52-485b-97b9-76ec0f790bdb" />
